### PR TITLE
Add other Python versions, for older or newer projects

### DIFF
--- a/styles/python35.toml
+++ b/styles/python35.toml
@@ -1,0 +1,2 @@
+["pyproject.toml".tool.poetry.dependencies]
+python = "^3.5"

--- a/styles/python37.toml
+++ b/styles/python37.toml
@@ -1,0 +1,2 @@
+["pyproject.toml".tool.poetry.dependencies]
+python = "^3.7"


### PR DESCRIPTION
E.g.: Skyler ETL still needs Python 3.5.